### PR TITLE
Fix SV rank model frequencies gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 - [2025-04-07]
+
+### `Fixed`
+
+- [#12](https://github.com/genomic-medicine-sweden/nallorefs/pull/12) - Fixed gaps in the SV rank model frequencies
+
 ## 0.1.0 - [2025-04-02]
 
 Initial release of genomic-medicine-sweden/nallorefs, created with the [nf-core](https://nf-co.re/) template.

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@ params {
 
     // Input options
     input                   = "$projectDir/assets/samplesheet.csv"
-    base_reference_dir      = 'https://github.com/Clinical-Genomics/reference-files/raw/ede27f6126d67b2d58ca3a5865d1911bffd0910d/'
+    base_reference_dir      = 'https://github.com/Clinical-Genomics/reference-files/raw/abdeebdf9d17ae2d128a4e1af3129a89fc065585/'
     clinvar_version         = 20250217
     clinvar                 = "https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/weekly/clinvar_${params.clinvar_version}.vcf.gz"
     clinvar_md5sum          = '9956fd8275a94f7e32aa283edd8bb172'


### PR DESCRIPTION
There was a gap in the frequencies in the SV-rank model: https://github.com/Clinical-Genomics/reference-files/issues/90

This PR changes the download path to the updated file. 

<!--
# genomic-medicine-sweden/nallo-refs pull request

Many thanks for contributing to genomic-medicine-sweden/nallo-refs!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo-refs/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo-refs/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
