### PR TITLE
Fix sort not using work directory as temporary directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - [#40](https://github.com/genomic-medicine-sweden/nallorefs/pull/40) - Added creation of reference fai
 - [#45](https://github.com/genomic-medicine-sweden/nallorefs/pull/45) - Added parameters for `cadd_prescored_indels_tsv` and `cadd_prescored_indels_tbi`
 - [#49](https://github.com/genomic-medicine-sweden/nallorefs/pull/49) - Updated CADD to 1.7
+- [#50](https://github.com/genomic-medicine-sweden/nallorefs/pull/50) - Fixed sort in `gunzip_remove_header_sort_dbnsfp` not using work directory as temporary directory
 
 ## 0.4.4 - [2026-03-11]
 

--- a/modules/local/gunzip_remove_header_sort_dbnsfp.nf
+++ b/modules/local/gunzip_remove_header_sort_dbnsfp.nf
@@ -53,7 +53,7 @@ process GUNZIP_REMOVE_HEADER_SORT_DBNSFP {
         ${archive} | \\
         tail -n +2 | \\
         cut -f 1,2,3,4,5,6,7,15,83,84,184,185,187,193 | \\
-        sort -k1,1 -k2,2n \\
+        sort --temporary-directory . -k1,1 -k2,2n \\
         > ${gunzip}
 
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
Sort should use the nextflow work directory are it's temporary sort location. 

<!--
# genomic-medicine-sweden/nallo-refs pull request

Many thanks for contributing to genomic-medicine-sweden/nallo-refs!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/genomic-medicine-sweden/nallo-refs/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/genomic-medicine-sweden/nallo-refs/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
